### PR TITLE
Fix docker UI build context issue

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,3 +31,4 @@
 
 # Node
 **/node_modules/
+**/.angular/


### PR DESCRIPTION
Add .angular to dockerignore to fix the docker build context size issue