### PR TITLE
inject environment variables into token placeholders

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ RUN npm ci
 
 # Copy the angular code and build
 COPY SDR-WebApp/. .
+
+# Replace tokens in environment.ts
+ARG BASE_URL
+ARG ENV_NAME
+RUN sed -i 's|{#Apim-BaseUrl#}|'"${BASE_URL}"'|g' src/environments/environment.ts
+RUN sed -i 's|{#Env-Name#}|'"${ENV_NAME}"'|g' src/environments/environment.ts
 RUN npm run build --production
 
 

--- a/SDR-WebApp/src/app/shared/services/service-call/http-wrapper.service.ts
+++ b/SDR-WebApp/src/app/shared/services/service-call/http-wrapper.service.ts
@@ -41,7 +41,6 @@ export class HttpWrapperService {
   getHTTPHeaders(): HttpHeaders {
     return new HttpHeaders({
       'Content-Type': 'application/json',
-      Authorization: 'Bearer ' + localStorage.getItem('token'),
       'Cache-control': 'no-store',
     });
   }


### PR DESCRIPTION
The BASE_URL and ENV_NAME are passed as build args into the dockerfile and the tokens in environment.ts are replaced with these values.

Also removes an authorization bearer token header which should have been removed as part of the PR that removed authentication.