### PR TITLE
Fix study comparison selection checkbox

### DIFF
--- a/SDR-WebApp/src/app/shared/shared.module.ts
+++ b/SDR-WebApp/src/app/shared/shared.module.ts
@@ -5,6 +5,7 @@ import { AuditTrailComponent } from './components/audit-trail/audit-trail.compon
 import { VersionComparisonComponent } from './components/version-comparison/version-comparison.component';
 import { ModalComponentComponent } from './components/modal-component/modal-component.component';
 import { SimpleSearchComponent } from './components/simple-search/simple-search/simple-search.component';
+import { CheckboxRenderer } from './components/checkbox-renderer/checkbox-renderer.component';
 
 @NgModule({
   imports: [SharedModuleConstants.MODULE_IMPORTS],
@@ -15,6 +16,7 @@ import { SimpleSearchComponent } from './components/simple-search/simple-search/
     VersionComparisonComponent,
     ModalComponentComponent,
     SimpleSearchComponent,
+    CheckboxRenderer
   ],
   providers: [SharedModuleConstants.MODULE_PROVIDERS],
   entryComponents: [SharedModuleConstants.ENTRY_COMPONENTS],


### PR DESCRIPTION
Fixes the study comparison selection checkbox by adding a missing import to the shared module:

<img width="1163" height="921" alt="image" src="https://github.com/user-attachments/assets/1e4e8ceb-edde-48d4-a623-30863a95a0e3" />
