### PR TITLE
Adds mechanism for Docker image to insert API URL at runtime

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -57,7 +57,6 @@ jobs:
 
       - name: Find and Replace Environment details from configuration
         run: |
-          find ${{ github.workspace }}/SDR-WebApp/src/environments/environment.ts -type f -exec sed -i ''s@{#Api-BaseUrl#}@'${{ vars.API_BASE_URL }}'@g'' {} \;
           find ${{ github.workspace }}/SDR-WebApp/src/environments/environment.ts -type f -exec sed -i ''s@{#Env-Name#}@'${{ vars.ENV_NAME }}'@g'' {} \;
 
       - name: Build App

--- a/SDR-WebApp/src/app/app-module.constants.ts
+++ b/SDR-WebApp/src/app/app-module.constants.ts
@@ -29,6 +29,6 @@ export class AppModuleConstants {
 
 export const protectedResources = {
   profileApi: {
-    endpoint: environment.BASE_URL,
+    endpoint: environment.API_BASE_URL,
   },
 };

--- a/SDR-WebApp/src/app/shared/services/service-call/service-call.service.ts
+++ b/SDR-WebApp/src/app/shared/services/service-call/service-call.service.ts
@@ -12,6 +12,17 @@ import { HttpHeaders } from '@angular/common/http';
 export class ServiceCall {
   constructor(private httpWrapperService: HttpWrapperService) {}
 
+  getApiBaseUrl(): string {
+    // Look first in the .env variable, which, if running in our Docker container, will expose a
+    // run-time-configurable API base URL, provided by environment variable of same name    
+    if ((window as any).env && (window as any).env.APP_API_BASE_URL) {
+      return (window as any).env.APP_API_BASE_URL;
+    } else {
+      // If run-time value was not available, return the build-time value for base URL
+      return environment.API_BASE_URL;
+    }
+  }
+
   getHttpOptions(usdmVersion: any): IHTTPOptions {
     return {
       headers: this.getHTTPHeaders(usdmVersion),
@@ -32,13 +43,13 @@ export class ServiceCall {
       studyURL = studyURL.substring(1);
     }
     return this.httpWrapperService.getData(
-      environment.BASE_URL + studyURL,
+      this.getApiBaseUrl() + studyURL,
       this.getHttpOptions(usdmVersion)
     );
   }
   getStudyLinks(studyId: any, versionId: any) {
     return this.httpWrapperService.getData(
-      environment.BASE_URL +
+      this.getApiBaseUrl() +
         CommonApiUrlList.STUDYLINKS.replace('{studyId}', studyId) +
         '?sdruploadversion=' +
         versionId
@@ -46,7 +57,7 @@ export class ServiceCall {
   }
   getAuditTrail(studyId: any) {
     return this.httpWrapperService.getData(
-      environment.BASE_URL +
+      this.getApiBaseUrl() +
         CommonApiUrlList.REVISIONHISTORY.replace('{studyId}', studyId)
     );
   }
@@ -57,25 +68,25 @@ export class ServiceCall {
     }
 
     return this.httpWrapperService.getData(
-      environment.BASE_URL + soaURL,
+      this.getApiBaseUrl() + soaURL,
       this.getHttpOptions(usdmVersion)
     );
   }
 
   getSearchResult(reqObj: any) {
     return this.httpWrapperService.postData(
-      environment.BASE_URL + CommonApiUrlList.SEARCHRESULT,
+      this.getApiBaseUrl() + CommonApiUrlList.SEARCHRESULT,
       reqObj
     );
   }
   getVersions() {
     return this.httpWrapperService.getData(
-      environment.BASE_URL + CommonApiUrlList.VERSIONSURL
+      this.getApiBaseUrl() + CommonApiUrlList.VERSIONSURL
     );
   }
   getSearchResultLight(reqObj: any) {
     return this.httpWrapperService.postData(
-      environment.BASE_URL + CommonApiUrlList.SEARCHRESULTLIGHT,
+      this.getApiBaseUrl() + CommonApiUrlList.SEARCHRESULTLIGHT,
       reqObj
     );
   }

--- a/SDR-WebApp/src/environments/environment.ts
+++ b/SDR-WebApp/src/environments/environment.ts
@@ -1,6 +1,8 @@
 export const environment = {
   production: false,
-
-  BASE_URL: '{#Api-BaseUrl#}',
+  //  This API BASE URL can be set for local development, or to create a build targetted against a
+  //  specific API endpoint. The Dockerfile will override this with the value of the
+  //  APP_API_BASE_URL property when running in a container, if a value is present
+  API_BASE_URL: '{#Api-BaseUrl#}',
   envName: '{#Env-Name#}',
 };

--- a/SDR-WebApp/src/index.html
+++ b/SDR-WebApp/src/index.html
@@ -17,10 +17,8 @@
       href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap"
       rel="stylesheet"
     />
-    <!-- <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons"
-      rel="stylesheet"
-    /> -->
+    <!-- This is used for injection of environment variables by the Docker build -->
+    <noscript id="env-insertion-point"></noscript>
   </head>
   <body class="mat-typography">
     <app-root></app-root>

--- a/SDR-WebApp/src/main.ts
+++ b/SDR-WebApp/src/main.ts
@@ -7,7 +7,7 @@ export function getBaseUrl() {
 }
 const providers = [
   {
-    provide: 'BASE_URL',
+    provide: 'API_BASE_URL',
     useFactory: getBaseUrl,
     deps: [],
   },

--- a/docker-inject-app-envs.sh
+++ b/docker-inject-app-envs.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# This script captures all environment variables whose name starts with APP_ and places them inside
+# of index.html, underneath the window.env variable, for use within the web app - for example, for 
+# configuring API base URLs.
+
+# Capture all environment variables starting with APP_ and make JSON string from them
+ENV_JSON="$(jq --compact-output --null-input 'env | with_entries(select(.key | startswith("APP_")))')"
+
+# Escape sed replacement's special characters: \, &, /.
+# No need to escape newlines, because --compact-output already removed them.
+# Inside of JSON strings newlines are already escaped.
+ENV_JSON_ESCAPED="$(printf "%s" "${ENV_JSON}" | sed -e 's/[\&/]/\\&/g')"
+
+sed -i "s/<noscript id=\"env-insertion-point\"><\/noscript>/<script>var env=${ENV_JSON_ESCAPED}<\/script>/g" /usr/share/nginx/html/index.html 


### PR DESCRIPTION
Uses a script to perform an environment variable substitution into index.html at Docker runtime. This is achieved by:
- Reading all ENV variables starting with `APP_` (currently expect this to only include `APP_API_BASE_URL`)
- Write this as a JSON variable inside a dedicated block in `index.html`
- The script is run automatically by Docker by placing it in `/docker-entrypoint.d/`
- In the UI, where the API base URL is required, we first check for the environment variable (run-time) property, and then fall back to the build-time property (from `environment.ts`)
- Removed the build-time copying of this BASE URL, since it is not required

Some references
https://medium.com/@tal.potlog/nginx-docker-and-the-hidden-hooks-f5782261fae
https://stackoverflow.com/questions/40608055/running-a-bash-script-before-startup-in-an-nginx-docker-container
https://stackoverflow.com/questions/66541451/passing-environment-variables-into-angular-docker-container