### PR TITLE
Add SPONSOR to SPONSORKEYS config

### DIFF
--- a/SDR-WebApp/src/app/shared/components/study-element-description/config/study-element-field-config.ts
+++ b/SDR-WebApp/src/app/shared/components/study-element-description/config/study-element-field-config.ts
@@ -2,7 +2,7 @@ const configList = {
   NAME: 'Item',
   KEYTOHIDE: ['id', 'studyId', 'uuid', 'workflowId'],
   EXCEPTIONFIELD: [''],
-  SPONSORKEYS: ['Clinical Study Sponsor', 'Sponsor_ID'],
+  SPONSORKEYS: ['Clinical Study Sponsor', 'Sponsor_ID', 'SPONSOR'],
   HEADING: 'Study Details',
   SPONSORID_KEY: 'orgCode',
   BLOCK_SIZE: 20,


### PR DESCRIPTION
Add SPONSOR to SPONSORKEYS config.

The end result is that the Sponsor ID column of a few of the tables in the UI now correctly populates with more sponsor IDs, specifically the ones where the organization has 'SPONSOR' decode value:

<img width="1719" height="858" alt="image" src="https://github.com/user-attachments/assets/9c3734c0-b262-4852-9cbc-bb68198249a6" />

This is necessary because the cdisc rules engine requires a decode of SPONSOR to get past the validation, and so now the DB contains studies with SPONSOR decode value